### PR TITLE
Simplify basic pattern of usage, introduce wrapper function validate_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ Fiasko Bro enables you to automatically review Python code in a git repo.
 Here's the simplest usage example:
 
 ```python
->>> from fiasko_bro import CodeValidator, LocalRepositoryInfo
->>> code_validator = CodeValidator()
->>> repo_to_validate = LocalRepositoryInfo('/path/to/repo/')
->>> code_validator.validate(repo_to_validate)
+>>> import fiasko_bro
+>>> fiasko_bro.validate_repo('/path/to/repo/')
 [('camel_case_vars', 'переименуй, например, WorkBook.')]
 ```
 The `validate` method returns list of tuples which consist of an error slug and an error message.

--- a/fiasko_bro/__init__.py
+++ b/fiasko_bro/__init__.py
@@ -1,3 +1,3 @@
-from .code_validator import CodeValidator
+from .code_validator import CodeValidator, validate_repo
 from .validator_helpers import  tokenized_validator
 from .repository_info import LocalRepositoryInfo

--- a/fiasko_bro/code_validator.py
+++ b/fiasko_bro/code_validator.py
@@ -1,6 +1,13 @@
 from collections import OrderedDict
 
 from . import validators
+from .repository_info import LocalRepositoryInfo
+
+
+def validate_repo(path_to_repo):
+    repo_to_validate = LocalRepositoryInfo(path_to_repo)
+    code_validator = CodeValidator()
+    return code_validator.validate(repo_to_validate)
 
 
 class CodeValidator:

--- a/fiasko_bro/code_validator.py
+++ b/fiasko_bro/code_validator.py
@@ -4,10 +4,9 @@ from . import validators
 from .repository_info import LocalRepositoryInfo
 
 
-def validate_repo(path_to_repo):
-    repo_to_validate = LocalRepositoryInfo(path_to_repo)
+def validate_repo(path_to_repo, original_repo=None):
     code_validator = CodeValidator()
-    return code_validator.validate(repo_to_validate)
+    return code_validator.validate(path_to_repo, original_repo)
 
 
 class CodeValidator:
@@ -237,11 +236,11 @@ class CodeValidator:
             )
         return warnings
 
-    def validate(self, solution_repo, original_repo=None, **kwargs):
+    def validate(self, path, original_repo=None, **kwargs):
         self.validator_arguments.update(kwargs)
         self.validator_arguments['whitelists'] = self.whitelists
         self.validator_arguments['blacklists'] = self.blacklists
-        self.validator_arguments['solution_repo'] = solution_repo
+        self.validator_arguments['solution_repo'] = LocalRepositoryInfo(path)
         if original_repo:
             self.validator_arguments['original_repo'] = original_repo
 

--- a/fiasko_bro/code_validator.py
+++ b/fiasko_bro/code_validator.py
@@ -4,9 +4,9 @@ from . import validators
 from .repository_info import LocalRepositoryInfo
 
 
-def validate_repo(path_to_repo, original_repo=None):
+def validate_repo(path_to_repo, path_to_original_repo=None):
     code_validator = CodeValidator()
-    return code_validator.validate(path_to_repo, original_repo)
+    return code_validator.validate(path_to_repo, path_to_original_repo)
 
 
 class CodeValidator:
@@ -236,13 +236,15 @@ class CodeValidator:
             )
         return warnings
 
-    def validate(self, path, original_repo=None, **kwargs):
+    def validate(self, repo_path, original_repo_path=None, **kwargs):
         self.validator_arguments.update(kwargs)
         self.validator_arguments['whitelists'] = self.whitelists
         self.validator_arguments['blacklists'] = self.blacklists
-        self.validator_arguments['solution_repo'] = LocalRepositoryInfo(path)
-        if original_repo:
-            self.validator_arguments['original_repo'] = original_repo
+        self.validator_arguments['solution_repo'] = LocalRepositoryInfo(
+            repo_path)
+        if original_repo_path:
+            self.validator_arguments['original_repo'] = LocalRepositoryInfo(
+                original_repo_path)
 
         errors = []
         for error_group_name, error_group in self.error_validator_groups.items():


### PR DESCRIPTION
Introduced simpler pattern of usage both `CodeValidator` and `LocalRepositoryInfo` classes are instantiated in the wrapper function `validate_repo(path_to_repo)` Fix #3