### PR TITLE
Fix syntax validator via ast trees

### DIFF
--- a/fiasko_bro/code_validator.py
+++ b/fiasko_bro/code_validator.py
@@ -137,12 +137,13 @@ class CodeValidator:
                 error_group,
                 self.validator_arguments
             )
-        if add_warnings and errors:
-            errors += self._run_warning_validators_until(
-                error_group_name,
-                self.validator_arguments
-            )
-            return errors
+            if errors:
+                if add_warnings:
+                    errors += self._run_warning_validators_until(
+                        error_group_name,
+                        self.validator_arguments
+                    )
+                return errors
         return errors
 
     def validate(self, repo_path, original_repo_path=None, **kwargs):

--- a/fiasko_bro/code_validator.py
+++ b/fiasko_bro/code_validator.py
@@ -42,12 +42,12 @@ class CodeValidator:
                 [validators.has_more_commits_than_origin],
             ),
             (
-                'readme',
-                [validators.has_readme_file],
-            ),
-            (
                 'syntax',
                 [validators.has_no_syntax_errors],
+            ),
+            (
+                'readme',
+                [validators.has_readme_file],
             ),
             (
                 'general',

--- a/fiasko_bro/repository_info.py
+++ b/fiasko_bro/repository_info.py
@@ -54,11 +54,14 @@ class LocalRepositoryInfo:
             ast_trees.append(tree)
         return filenames, main_file_contents, ast_trees
 
-    def get_ast_trees(self, with_filenames=False, with_file_content=False, whitelist=None):
+    def get_ast_trees(self, with_filenames=False, with_file_content=False, whitelist=None, return_none=False):
         ast_trees_copy = copy.deepcopy(self._ast_trees)
         all_items = zip(self._python_filenames, self._main_file_contents, ast_trees_copy)
         filtered_items = self.filter_file_paths(all_items, whitelist)
-        filtered_items = [r for r in filtered_items if r[2] is not None]
+        if return_none:
+            filtered_items = [r for r in filtered_items]
+        else:
+            filtered_items = [r for r in filtered_items if r[2] is not None]
 
         if with_filenames:
             if with_file_content:

--- a/fiasko_bro/validators/syntax.py
+++ b/fiasko_bro/validators/syntax.py
@@ -6,7 +6,7 @@ from .. import url_helpers
 
 
 def has_no_syntax_errors(solution_repo, *args, **kwargs):
-    for filename, tree in solution_repo.get_ast_trees(with_filenames=True):
+    for filename, tree in solution_repo.get_ast_trees(with_filenames=True, return_none=True):
         if tree is None:
             return 'syntax_error', filename
 

--- a/test_fixtures/general_repo/file_with_variables_shadowing_default_names.py
+++ b/test_fixtures/general_repo/file_with_variables_shadowing_default_names.py
@@ -1,0 +1,3 @@
+def dict(bar, foo):
+    tuple = bar, foo
+    return tuple

--- a/test_fixtures/syntax_repo/file_with_syntax_error.py
+++ b/test_fixtures/syntax_repo/file_with_syntax_error.py
@@ -1,0 +1,3 @@
+def foo(bar):
+    if bar
+        return 1

--- a/tests/test_general_validators/test_has_no_variables_shadow_default_names.py
+++ b/tests/test_general_validators/test_has_no_variables_shadow_default_names.py
@@ -1,0 +1,12 @@
+from fiasko_bro import validators
+
+
+def test_has_no_variables_shadow_defaults_fail(test_repo):
+    output = validators.has_no_variables_that_shadow_default_names(test_repo)
+    assert isinstance(output, tuple)
+    assert output[0] == 'title_shadows'
+
+
+def test_has_no_variables_shadow_defaults_ok(origin_repo):
+    output = validators.has_no_variables_that_shadow_default_names(origin_repo)
+    assert output is None

--- a/tests/test_syntax_validators/conftest.py
+++ b/tests/test_syntax_validators/conftest.py
@@ -1,0 +1,20 @@
+import os.path
+
+import pytest
+import git
+
+from fiasko_bro.repository_info import LocalRepositoryInfo
+
+
+@pytest.fixture(scope="module")
+def test_repo():
+    test_repo_dir = 'test_fixtures{}syntax_repo'.format(os.path.sep)
+    git.Repo.init(test_repo_dir)
+    return LocalRepositoryInfo(test_repo_dir)
+
+
+@pytest.fixture(scope="module")
+def control_repo():
+    control_repo_dir = 'test_fixtures{}general_repo'.format(os.path.sep)
+    git.Repo.init(control_repo_dir)
+    return LocalRepositoryInfo(control_repo_dir)

--- a/tests/test_syntax_validators/test_has_no_syntax_errors.py
+++ b/tests/test_syntax_validators/test_has_no_syntax_errors.py
@@ -1,0 +1,12 @@
+from fiasko_bro import validators
+
+
+def test_has_no_syntax_errors_fail(test_repo):
+    output = validators.has_no_syntax_errors(test_repo)
+    assert isinstance(output, tuple)
+    assert output[0] == 'syntax_error'
+
+
+def test_has_no_syntax_errors_ok(control_repo):
+    output = validators.has_no_syntax_errors(control_repo)
+    assert output is None


### PR DESCRIPTION
Also moved syntax validator group above readme group because in case of repo with single file with syntax error fiasko would complain only on absence of readme file, which is less important than syntax error, i think