### PR TITLE
An attempt to close #73

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,24 @@
 [metadata]
-description-file = README.md
+name = Fiasko Bro
+version = 0.0.1.1
+description = Automatic code validator
+long_description = The project validates for common pitfalls
+keywords = static, code, analysis, code, quality
+url = https://github.com/devmanorg/fiasko_bro
+license = MIT
+author = Ilya Lebedev
+author_email = melevir@gmail.com
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Natural Language :: English
+    Operating System :: MacOS
+    Operating System :: POSIX :: Linux
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Software Development :: Quality Assurance
 
 [compile_catalog]
 domain = fiasko_bro

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Libraries :: Python Modules
+python_requires = >=3.4
 
 [compile_catalog]
 domain = fiasko_bro

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,14 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Operating System :: MacOS
-    Operating System :: POSIX :: Linux
-    Operating System :: Microsoft :: Windows
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Quality Assurance
+    Topic :: Software Development :: Libraries :: Python Modules
 
 [compile_catalog]
 domain = fiasko_bro

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-from codecs import open
 from os import path
 from pip.req import parse_requirements
 
@@ -26,34 +25,6 @@ class InstallWithCompile(install):
 
 
 setup(
-    name='Fiasko Bro',
-
-    version='0.0.1.1',
-
-    description='Automatic code validator',
-    long_description='The project validates for common pitfalls',  # TODO: generate README
-
-    url='https://github.com/devmanorg/fiasko_bro',
-
-    license='MIT',
-
-    author='Ilya Lebedev',
-    author_email='melevir@gmail.com',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Operating System :: MacOS',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development :: Quality Assurance',
-    ],
-
-    keywords='static code analysis code quality',
-
     packages=find_packages(),
     # since babel appears both in setup_requires and install_requires,
     # our package can't be instaled with python setup.py install command


### PR DESCRIPTION
Going issue-by-issue:

> now it is advised to store repo metadata in `setup.cfg`

See the description to the commit: https://github.com/devmanorg/fiasko_bro/commit/4704494105850ab3f078abc4a71abb389bfece4c

It's important to note: **it will not work with setuptools older than 30.3.0**. 

Currently when I do `python -m venv venv`, I get `setuptools-28.8.0` so this will not work with `venv` (or `Pipenv` and `virtualenv`, for that matter) out of the box without running `python -m pip install -U setuptools pip`.

> wrong requirements separation (install_requires vs tests_require)

We've separated them in #89.

> wrong requirements file handling

Now that we are using Pipfile, we [are not supposed to keep](https://github.com/pypa/pipenv/issues/1263#issuecomment-362600555) `requirements.txt` at all, but we do so for compatibility reasons as described in #89.

> wrong classifiers 

I'm not exactly sure which ones were wrong, but I did find some ways to improve them: https://github.com/devmanorg/fiasko_bro/commit/40d6d48c537325505d99dd107123ffbc564c2ea4

> There is also an automated checker for `setup.py` that checks this things

Didn't find it.