### PR TITLE
Add validator for pdb breakpoint (closes #57)

### DIFF
--- a/fiasko_bro/ast_helpers.py
+++ b/fiasko_bro/ast_helpers.py
@@ -35,6 +35,17 @@ def get_all_namedtuple_names(tree):
     return nametuples_names
 
 
+def get_all_import_names_mentioned_in_import(tree):
+    import_names = []
+    imports = get_all_imports(tree)
+    for import_node in imports:
+        if isinstance(import_node, ast.ImportFrom):
+            import_names.append(import_node.module)
+        elif isinstance(import_node, ast.Import):
+            import_names += [import_object.name for import_object in import_node.names]
+    return import_names
+
+
 def get_all_imported_names_from_tree(tree):
     imported_names = []
     for node in ast.walk(tree):

--- a/fiasko_bro/validators/imports.py
+++ b/fiasko_bro/validators/imports.py
@@ -15,3 +15,10 @@ def has_no_local_imports(solution_repo, whitelists, *args, **kwargs):
         if ast_helpers.is_has_local_imports(tree):
             filename = url_helpers.get_filename_from_path(filepath)
             return 'has_local_import', filename
+
+
+def has_no_pdb_breakpoints(solution_repo, *args, **kwargs):
+    for filepath, tree in solution_repo.get_ast_trees(with_filenames=True):
+        if 'pdb' in ast_helpers.get_all_import_names_mentioned_in_import(tree):
+            filename = url_helpers.get_filename_from_path(filepath)
+            return 'has_pdb_breakpoint', filename

--- a/test_fixtures/general_repo/file_with_pdb_breakpoint.py
+++ b/test_fixtures/general_repo/file_with_pdb_breakpoint.py
@@ -1,0 +1,3 @@
+
+
+import pdb; pdb.set_trace()

--- a/tests/test_general_validators/test_has_no_pdb_breakpoints.py
+++ b/tests/test_general_validators/test_has_no_pdb_breakpoints.py
@@ -1,0 +1,12 @@
+from fiasko_bro.validators import has_no_pdb_breakpoints
+
+
+def test_has_no_pdb_breakpoint_fails(test_repo):
+    expected_output = 'has_pdb_breakpoint', 'file_with_pdb_breakpoint.py'
+    output = has_no_pdb_breakpoints(test_repo)
+    assert output == expected_output
+
+
+def test_has_no_pdb_breakpoint_succeeds(origin_repo):
+    output = has_no_pdb_breakpoints(origin_repo)
+    assert output is None


### PR DESCRIPTION
I didn't go  the extra mile to reimplement all of the [flake8-debugger](https://pypi.python.org/pypi/flake8-debugger) functionality. The validator simply checks for statements like `import pdb` and `from pdb import ...`.

Adds `has_pdb_breakpoint` error slug.